### PR TITLE
Support Standard Arguments

### DIFF
--- a/cycle.js
+++ b/cycle.js
@@ -128,12 +128,12 @@ function retrocycle($) {
 }
 
 module.exports = {
-  stringify: function stringifyJC(object) {
-    return JSON.stringify(decycle(object))
+  stringify: function stringifyJC(object, replacer, space) {
+    return JSON.stringify(decycle(object), replacer, space)
   },
 
-  parse: function parseJC($) {
-    return retrocycle(JSON.parse($))
+  parse: function parseJC($, reviver) {
+    return retrocycle(JSON.parse($, reviver))
   },
 
   decycle: decycle,


### PR DESCRIPTION
Pass-through the remaining standard arguments of JSON.stringify and JSON.parse.
This supports formatting and other concerns.

ref:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse