### PR TITLE
Bugfix

### DIFF
--- a/cycle.js
+++ b/cycle.js
@@ -44,11 +44,16 @@
                 name,       // Property name
                 nu;         // The new object or array
 
-            var _value = value && value.toJSON instanceof Function ? value.toJSON() : value;
+            var _value = value
+
+            try {
+              _value = value.toJSON()
+            } catch (error) {}
+
             // typeof null === 'object', so go on if this value is really an object but not
             // one of the weird builtin objects.
 
-            if (typeof _value === 'object' && _value !== null) {
+            if (typeof _value === 'object' && _value) {
                 // If the value is an object or array, look to see if we have already
                 // encountered it. If so, return a $ref/path object. This is a hard way,
                 // linear search that will get slower as the number of unique objects grows.


### PR DESCRIPTION
As has been found out in browser context with the ``last release of Cycle.js`` (``1.4.0``), if one tries to stringify some global object like ``globalThis`` (``Window``), the function ``decycle`` along with inspecting global object itself walks thru DOM (since ``document`` is child property of ``globalThis``, and ``document`` [technically is an object](https://developer.mozilla.org/en-US/docs/Web/API/Window/document)). Everything flows fine till the observed page contains no ``iframe``

But if there's one or more ``iframe`` at the observed page, and the site utilises ``X-Frame-Option`` directive with ``SAMEORIGIN`` value [for security reasons to avoid click-jacking attacks](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) (lions' share of sites nowadays do), when ``decycle`` reaches ``iframe`` (which is also technically an object) and tries to check ``object.toJSON`` property, the browser throws [DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) reporting ``Blocked a frame with origin "https://current.origin" from accessing a cross-origin frame.``, causing ``decycle`` to fail

This fix implements alternative tactic of accessing ``object.toJSON`` property, and thus avoids ``DOMException`` and lets ``decycle`` to finish the job